### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,8 @@
 name: Mark stale issues and pull requests
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/mrvytautaskelmelis/home-assistant-addons/security/code-scanning/1](https://github.com/mrvytautaskelmelis/home-assistant-addons/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the functionality of the `actions/stale` action, the workflow requires `contents: write`, `issues: write`, and `pull-requests: write` permissions. These permissions allow the workflow to mark issues and pull requests as stale and add labels or comments as needed.

The `permissions` block should be added immediately after the `name` field in the workflow file to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
